### PR TITLE
Switch submodule to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/test-suite"]
 	path = test/test-suite
-	url = git://github.com/json-schema/JSON-Schema-Test-Suite.git
+	url = https://github.com/json-schema/JSON-Schema-Test-Suite.git


### PR DESCRIPTION
GitHub disabled anonymous git access 2021-09-01. Since then it wasn't
possible to run `git submodule update` locally or in CI. Rather than
require authentication, switch to fetch submodules via https.